### PR TITLE
Refactor CloudFront invalidation step and remove build output verific…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,6 @@ jobs:
 
       - name: Build application
         run: npm run build
-        
-      - name: Verify build output
-        run: ls -la dist/
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -37,8 +34,10 @@ jobs:
       - name: Deploy to S3
         run: |
           aws s3 sync dist/ s3://${{ secrets.AWS_S3_BUCKET }} --delete
-
-      - name: Invalidate CloudFront distribution
-        if: secrets.CLOUDFRONT_DISTRIBUTION_ID != ''
+          
+      - name: Invalidate CloudFront distribution (if using CloudFront)
+        env:
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        if: ${{ env.CLOUDFRONT_DISTRIBUTION_ID != '' }}
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+          aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` by removing unnecessary steps and improving the handling of CloudFront invalidation. The changes streamline the process and enhance clarity for conditional operations.

### Workflow simplifications:
* Removed the "Verify build output" step, which listed the contents of the `dist/` directory, as it was deemed unnecessary. (`[.github/workflows/deploy.ymlL27-L29](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L27-L29)`)

### Improvements to CloudFront invalidation:
* Updated the "Invalidate CloudFront distribution" step to include a clearer name and use an environment variable (`env.CLOUDFRONT_DISTRIBUTION_ID`) for conditional checks and command execution, improving readability and maintainability. (`[.github/workflows/deploy.ymlL41-R43](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L41-R43)`)